### PR TITLE
feat: guardrails de git nativos opcionales (protección de ramas)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,18 @@
+# Guardrails de git (opcional)
+
+Hooks nativos de git que refuerzan el branching de
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md):
+
+- `pre-commit` — bloquea commits directos en `main` / `master` / `develop`.
+- `pre-push` — bloquea push directo a esas ramas.
+
+No están activos por defecto. Para habilitarlos en tu clon:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Para desactivarlos: `git config --unset core.hooksPath`.
+
+> Son una red de seguridad **local**; no sustituyen la protección de ramas del
+> lado del servidor (GitHub). No requieren ninguna herramienta de IA.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Guardrail opcional: bloquea commits directos en ramas protegidas.
+# Actívalo en tu clon con:  git config core.hooksPath .githooks
+set -euo pipefail
+
+branch="$(git symbolic-ref --short -q HEAD 2>/dev/null || true)"
+case "$branch" in
+  main|master|develop)
+    echo "⛔ git-guardrails: no hagas commit directo en '$branch'. Crea una rama feat/…|fix/…|docs/…|chore/… (CONTRIBUTING.md)." >&2
+    exit 1
+    ;;
+esac
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Guardrail opcional: bloquea push directo a ramas protegidas.
+# Actívalo en tu clon con:  git config core.hooksPath .githooks
+# stdin (una línea por ref):  <local ref> <local sha> <remote ref> <remote sha>
+set -euo pipefail
+
+protected='^refs/heads/(main|master|develop)$'
+while read -r localref localsha remoteref remotesha; do
+  [ -z "${remoteref:-}" ] && continue
+  if [[ "$remoteref" =~ $protected ]]; then
+    echo "⛔ git-guardrails: no hagas push directo a '${remoteref#refs/heads/}'. Abre un PR desde tu rama (CONTRIBUTING.md)." >&2
+    exit 1
+  fi
+done
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,9 @@ git push origin hotfix/descripcion-del-fix
 
 - `main` y `develop` están protegidas: no se permite push directo, solo vía PR aprobado.
 - Mantén tu rama actualizada con `develop` (rebase o merge) antes de abrir el PR.
+- Opcional: activa los [guardrails de git](.githooks/README.md) (`git config core.hooksPath .githooks`)
+  para que estas reglas se apliquen de forma local — bloquean commits/push directos a las
+  ramas protegidas.
 
 ## Estándares de Código
 


### PR DESCRIPTION
# Descripción

Añade una red de seguridad local para el branching de `CONTRIBUTING.md` usando **git hooks nativos**.

## Tipo de Cambio

- [x] Nueva funcionalidad

## Cambios Realizados

- `.githooks/pre-commit` — bloquea commits directos en `main`/`master`/`develop`.
- `.githooks/pre-push` — bloquea push directo a esas ramas.
- `.githooks/README.md` — qué hacen y cómo activarlos.
- Nota en `CONTRIBUTING.md` (Políticas de ramas).

**Off por defecto** (opt-in): se activan con `git config core.hooksPath .githooks`.

## Instrucciones de Prueba

En un repo temporal con `core.hooksPath` apuntando a `.githooks`:
1. `git commit` en `main` → bloqueado; en `feat/x` → permitido.
2. `pre-push` con ref a `main` → bloqueado; a `feat/x` → permitido.

## Impacto

- Breaking changes: No (opt-in, desactivado por defecto).